### PR TITLE
Implement show command to display certificate info

### DIFF
--- a/cmd/show.go
+++ b/cmd/show.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,35 +17,37 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/fanzy618/easycert/pkg/cert"
 )
 
 // showCmd represents the show command
 var showCmd = &cobra.Command{
 	Use:   "show",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
+	Short: "Show certificate information",
+	Long:  "Load a certificate from disk and print its details. The certificate location is determined by --name and --dir flags.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, _, err := cert.LoadFromDisk(globalCfg.Dir, globalCfg.Name)
+		if err != nil {
+			return err
+		}
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("show called")
+		fmt.Fprintf(cmd.OutOrStdout(), "Subject: %s\n", c.Subject.String())
+		fmt.Fprintf(cmd.OutOrStdout(), "DNSNames: %s\n", strings.Join(c.DNSNames, ", "))
+		var ips []string
+		for _, ip := range c.IPAddresses {
+			ips = append(ips, ip.String())
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "IPAddresses: %s\n", strings.Join(ips, ", "))
+		fmt.Fprintf(cmd.OutOrStdout(), "NotBefore: %s\n", c.NotBefore.Format("2006-01-02T15:04:05Z07:00"))
+		fmt.Fprintf(cmd.OutOrStdout(), "NotAfter: %s\n", c.NotAfter.Format("2006-01-02T15:04:05Z07:00"))
+		return nil
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(showCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// showCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// showCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"bytes"
+	"crypto/x509"
+	"net"
+	"strings"
+	"testing"
+
+	certutil "k8s.io/client-go/util/cert"
+
+	"github.com/fanzy618/easycert/pkg/cert"
+)
+
+func TestShowCmd(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &cert.Config{
+		Config: certutil.Config{
+			CommonName: "test",
+			AltNames: certutil.AltNames{
+				DNSNames: []string{"example.com"},
+				IPs:      []net.IP{net.ParseIP("127.0.0.1")},
+			},
+		},
+		Name: "test",
+		Dir:  tmpDir,
+		Bits: 2048,
+	}
+
+	key, err := cert.NewKey("", cfg.Bits)
+	if err != nil {
+		t.Fatalf("NewKey: %v", err)
+	}
+	caCert, err := certutil.NewSelfSignedCACert(cfg.Config, key)
+	if err != nil {
+		t.Fatalf("NewSelfSignedCACert: %v", err)
+	}
+	if err := cert.WriteToDisk(cfg.Dir, cfg.Name, []*x509.Certificate{caCert}, key); err != nil {
+		t.Fatalf("WriteToDisk: %v", err)
+	}
+
+	globalCfg = cfg
+	buf := new(bytes.Buffer)
+	showCmd.SetOut(buf)
+	if err := showCmd.RunE(showCmd, []string{}); err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Subject:") {
+		t.Fatalf("expected output to contain Subject, got %s", out)
+	}
+}

--- a/pkg/cert/cert.go
+++ b/pkg/cert/cert.go
@@ -47,7 +47,7 @@ type Config struct {
 func NewKey(algorithm string, bits int) (crypto.Signer, error) {
 	key, err := rsa.GenerateKey(rand.Reader, bits)
 	if err != nil {
-		log.Println("NewKey failed:", err.Error)
+		log.Println("NewKey failed:", err.Error())
 		return nil, err
 	}
 	return key, nil


### PR DESCRIPTION
## Summary
- add `show` command that loads certificate from disk and prints fields
- fix private key generator error logging
- add test ensuring the show command outputs certificate info

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68944986af08832da1337df621c29076