### PR TITLE
Increase default RSA key size and allow duration configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ The following flags are available to all commands:
 - `--orgs` – comma-separated list of organizations (default: `easycert`)
 - `--dns` – repeatable flag for DNS names
 - `--ip` – repeatable flag for IP addresses
-- `-b` – RSA key size in bits (default: `2048`)
+- `-b` – RSA key size in bits (default: `4096`)
+- `--duration` – validity duration for certificates (default: `1y`, accepts values like `30d`, `12h`)
 
 ## Commands
 
@@ -57,7 +58,7 @@ Subject: CN=mysite.com,O=easycert
 DNSNames: mysite1.com, mysite2.com
 IPAddresses:
 NotBefore: 2025-08-07T06:46:02Z
-NotAfter: 2035-08-05T06:46:04Z
+NotAfter: 2026-08-07T06:46:04Z
 ```
 
 ## License

--- a/cmd/ca.go
+++ b/cmd/ca.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,8 +19,6 @@ import (
 	"crypto/x509"
 
 	"github.com/spf13/cobra"
-
-	certutil "k8s.io/client-go/util/cert"
 
 	"github.com/fanzy618/easycert/pkg/cert"
 )
@@ -63,14 +61,7 @@ func createCA(cfg *cert.Config) error {
 	if err != nil {
 		return err
 	}
-
-	ca, err := certutil.NewSelfSignedCACert(
-		certutil.Config{
-			CommonName:   cfg.CommonName,
-			Organization: cfg.Organization,
-		},
-		key,
-	)
+	ca, err := cert.NewSelfSignedCACert(cfg, key)
 	if err != nil {
 		return err
 	}

--- a/cmd/cert.go
+++ b/cmd/cert.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	certutil "k8s.io/client-go/util/cert"
 
 	"github.com/fanzy618/easycert/pkg/cert"
 )
@@ -83,7 +82,7 @@ func createFromCA(cfg *cert.Config, caName string) error {
 	} else {
 		caKey, err = cert.NewKey("", cfg.Bits)
 		if err == nil {
-			caCert, err = certutil.NewSelfSignedCACert(cfg.Config, caKey)
+			caCert, err = cert.NewSelfSignedCACert(cfg, caKey)
 		}
 		if err != nil {
 			return err
@@ -119,7 +118,7 @@ func newCertAndKey(caCert *x509.Certificate, caKey crypto.Signer, cfg *cert.Conf
 		IPAddresses:  cfg.AltNames.IPs,
 		SerialNumber: serial,
 		NotBefore:    caCert.NotBefore,
-		NotAfter:     time.Now().Add(time.Hour * 24 * 365 * 10).UTC(),
+		NotAfter:     time.Now().Add(cfg.ValidFor).UTC(),
 		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,11 +28,20 @@ import (
 
 var cfgFile string
 var globalCfg = &cert.Config{}
+var durationStr string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "easycert",
 	Short: "Help you create certificates easily",
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		dur, err := cert.ParseDuration(durationStr)
+		if err != nil {
+			return err
+		}
+		globalCfg.ValidFor = dur
+		return nil
+	},
 
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
@@ -61,7 +70,8 @@ func init() {
 	rootCmd.PersistentFlags().StringSliceVar(&globalCfg.AltNames.DNSNames, "dns", []string{}, "DNS")
 	rootCmd.PersistentFlags().IPSliceVar(&globalCfg.AltNames.IPs, "ip", nil, "IPs")
 
-	rootCmd.PersistentFlags().IntVar(&globalCfg.Bits, "b", 2048, "Bits of RSA key")
+	rootCmd.PersistentFlags().IntVar(&globalCfg.Bits, "b", 4096, "Bits of RSA key")
+	rootCmd.PersistentFlags().StringVar(&durationStr, "duration", "1y", "Validity duration (e.g., 30d, 12h, 1y)")
 
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strings"
 	"testing"
+	"time"
 
 	certutil "k8s.io/client-go/util/cert"
 
@@ -22,16 +23,17 @@ func TestShowCmd(t *testing.T) {
 				IPs:      []net.IP{net.ParseIP("127.0.0.1")},
 			},
 		},
-		Name: "test",
-		Dir:  tmpDir,
-		Bits: 2048,
+		Name:     "test",
+		Dir:      tmpDir,
+		Bits:     4096,
+		ValidFor: time.Hour * 24 * 365,
 	}
 
 	key, err := cert.NewKey("", cfg.Bits)
 	if err != nil {
 		t.Fatalf("NewKey: %v", err)
 	}
-	caCert, err := certutil.NewSelfSignedCACert(cfg.Config, key)
+	caCert, err := cert.NewSelfSignedCACert(cfg, key)
 	if err != nil {
 		t.Fatalf("NewSelfSignedCACert: %v", err)
 	}

--- a/pkg/cert/duration.go
+++ b/pkg/cert/duration.go
@@ -1,0 +1,33 @@
+package cert
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ParseDuration converts a human-friendly duration string into a time.Duration.
+// It supports the suffixes "y" for years (365 days) and "d" for days in addition
+// to the standard time.ParseDuration formats like "720h" or "15m".
+func ParseDuration(s string) (time.Duration, error) {
+	if strings.HasSuffix(s, "y") {
+		n, err := strconv.Atoi(strings.TrimSuffix(s, "y"))
+		if err != nil {
+			return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+		}
+		return time.Duration(n) * 365 * 24 * time.Hour, nil
+	}
+	if strings.HasSuffix(s, "d") {
+		n, err := strconv.Atoi(strings.TrimSuffix(s, "d"))
+		if err != nil {
+			return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+		}
+		return time.Duration(n) * 24 * time.Hour, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+	}
+	return d, nil
+}


### PR DESCRIPTION
## Summary
- default RSA key size upgraded to 4096 bits
- certificates and CAs now default to 1‑year validity with configurable duration
- document new `--duration` flag and updated defaults
- duration flag uses human‑readable default `1y` and accepts `d`/`y` suffixes

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689453de4414832da4d86233f686364d